### PR TITLE
make title of page containing preamble configurable

### DIFF
--- a/scripts/ConfluenceConfig.groovy
+++ b/scripts/ConfluenceConfig.groovy
@@ -7,6 +7,8 @@
 // - 'url': absolute URL to an asciidoc generated html file to be exported
 // - 'ancestorId' (optional): the id of the parent page in Confluence; leave this empty
 // 							  if a new parent shall be created in the space
+// - 'preambleTitle' (optional): the title of the page containing the preamble (everything
+//                               before the first second level heading). Default is 'arc42'
 //
 // only 'file' or 'url' is allowed. If both are given, 'url' is ignored
 input = [

--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -337,7 +337,7 @@ config.input.each { input ->
     // let's try to select the "first page" and push it to confluence
     dom.select('div#preamble div.sectionbody').each { pageBody ->
         pageBody.select('div.sect2').unwrap()
-        masterid = pushToConfluence "arc42", pageBody, input.ancestorId
+        masterid = pushToConfluence input.preambleTitle ?: "arc42", pageBody, input.ancestorId
     }
     // <div class="sect1"> are the main headings
     // let's extract these and push them to confluence


### PR DESCRIPTION
The text between the title and the first second level heading (the preamble) is put onto a separate page who's title is a hard-coded "arc42".

This PR allows users to override the page title for each input document.