### PR TITLE
make internal cross references work for Confluence pages

### DIFF
--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -165,6 +165,10 @@ def rewriteInternalLinks = { body, anchors, pageAnchors ->
             def anchor = href.substring(1)
             def pageTitle = anchors[anchor] ?: pageAnchors[anchor]
             if (pageTitle) {
+                // as Confluence insists on link texts to be contained
+                // inside CDATA, we have to strip all HTML and
+                // potentially loose styling that way.
+                a.html(a.text())
                 a.wrap("<ac:link${anchors.containsKey(anchor) ? ' ac:anchor="' + anchor + '"' : ''}></ac:link>")
                    .before("<ri:page ri:content-title=\"${realTitle pageTitle}\"/>")
                    .wrap('<ac:plain-text-link-body><cdata-placeholder></cdata-placeholder></ac:plain-text-link-body>')

--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -346,9 +346,7 @@ pushPages = { pages ->
     pages.each { page ->
         println page.title
         def id = pushToConfluence page.title, page.body, page.parent
-        page.children.each { subPage ->
-            subPage.parent = id
-        }
+        page.children*.parent = id
         pushPages page.children
     }
 }

--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -359,18 +359,10 @@ def pushToConfluence = { pageTitle, pageBody, parentId, anchors ->
 
 def parseAnchors = { page ->
     def anchors = [:]
-    page.body.select('a[name]').each { anchor ->
-        def name = anchor.attr('name')
-        anchors[name] = page.title
-        anchor.after("<ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">${name}</ac:parameter></ac:structured-macro>")
-        anchor.remove()
-    }
     page.body.select('[id]').each { anchor ->
         def name = anchor.attr('id')
-        if (!name.startsWith('_')) {
-            anchors[name] = page.title
-            anchor.before("<ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">${name}</ac:parameter></ac:structured-macro>")
-        }
+        anchors[name] = page.title
+        anchor.before("<ac:structured-macro ac:name=\"anchor\"><ac:parameter ac:name=\"\">${name}</ac:parameter></ac:structured-macro>")
     }
     anchors
 }

--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -153,6 +153,10 @@ def uploadAttachment = { def pageId, String url, String fileName, String note ->
 }
 
 
+def realTitle = { pageTitle ->
+    confluencePagePrefix + pageTitle
+}
+
 def rewriteInternalLinks = { body, anchors, pageAnchors ->
     // find internal cross-references and replace them with link macros
     body.select('a[href]').each { a ->
@@ -162,7 +166,7 @@ def rewriteInternalLinks = { body, anchors, pageAnchors ->
             def pageTitle = anchors[anchor] ?: pageAnchors[anchor]
             if (pageTitle) {
                 a.wrap("<ac:link${anchors.containsKey(anchor) ? ' ac:anchor="' + anchor + '"' : ''}></ac:link>")
-                   .before("<ri:page ri:content-title=\"${pageTitle}\"/>")
+                   .before("<ri:page ri:content-title=\"${realTitle pageTitle}\"/>")
                    .wrap('<ac:plain-text-link-body><cdata-placeholder></cdata-placeholder></ac:plain-text-link-body>')
                    .unwrap()
             }
@@ -289,7 +293,7 @@ def pushToConfluence = { pageTitle, pageBody, parentId, anchors, pageAnchors ->
 
     def request = [
             type : 'page',
-            title: confluencePagePrefix + pageTitle,
+            title: realTitle(pageTitle),
             space: [
                     key: confluenceSpaceKey
             ],


### PR DESCRIPTION
For the longish story see #49 

I've stripped all HTML markup from link texts now, seems to work well for our use case.