### PR TITLE
[BUGFIX] Reference Online Images (Confluence)

### DIFF
--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -252,13 +252,21 @@ def parseBody =  { body, anchors, pageAnchors ->
         }
         def src = img.attr('src')
         println "    image: "+src
-        def newUrl = baseUrl.toString().replaceAll('\\\\','/').replaceAll('/[^/]*$','/')+src
-        def fileName = (src.tokenize('/')[-1])
 
-        trythis {
-            deferredUpload <<  [0,newUrl,fileName,"automatically uploaded"]
+        //it is not an online image, so upload it to confluence and use the ri:attachment tag
+        if(!src.startsWith("http")) {
+          def newUrl = baseUrl.toString().replaceAll('\\\\','/').replaceAll('/[^/]*$','/')+src
+          def fileName = (src.tokenize('/')[-1])
+
+          trythis {
+              deferredUpload <<  [0,newUrl,fileName,"automatically uploaded"]
+          }
+          img.after("<ac:image ac:align=\"center\" ac:width=\"500\"><ri:attachment ri:filename=\"${fileName}\"/></ac:image>")
         }
-        img.after("<ac:image ac:align=\"center\" ac:width=\"500\"><ri:attachment ri:filename=\"${fileName}\"/></ac:image>")
+        // it is an online image, so we have to use the ri:url tag
+        else {
+          img.after("<ac:image ac:align=\"center\" ac:width=\"500\"><ri:url ri:value=\"${src}\"/></ac:image>")
+        }
         img.remove()
     }
     rewriteInternalLinks body, anchors, pageAnchors


### PR DESCRIPTION
Currently, it was not possible to reference online images (i.e. 'http://server/image'). The confluence script failed with an error.

This fix will check if the image source starts with 'http' and skip the upload to confluence and instead use another tag to correctly include online images.

Please test before merging, because my setup currently only includes one local image (which worked fine).