### PR TITLE
Adopted image attributes _width_ and _align_ to confluence

### DIFF
--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -302,6 +302,8 @@ def parseBody =  { body, anchors, pageAnchors ->
             //println attribute.dump()
         }
         def src = img.attr('src')
+        def imgWidth = img.attr('width')?:500
+        def imgAlign = img.attr('align')?:"center"
         println "    image: "+src
 
         //it is not an online image, so upload it to confluence and use the ri:attachment tag
@@ -312,11 +314,11 @@ def parseBody =  { body, anchors, pageAnchors ->
           trythis {
               deferredUpload <<  [0,newUrl,fileName,"automatically uploaded"]
           }
-          img.after("<ac:image ac:align=\"center\" ac:width=\"500\"><ri:attachment ri:filename=\"${fileName}\"/></ac:image>")
+          img.after("<ac:image ac:align=\"${imgAlign}\" ac:width=\"${imgWidth}\"><ri:attachment ri:filename=\"${fileName}\"/></ac:image>")
         }
         // it is an online image, so we have to use the ri:url tag
         else {
-          img.after("<ac:image ac:align=\"center\" ac:width=\"500\"><ri:url ri:value=\"${src}\"/></ac:image>")
+          img.after("<ac:image ac:align=\"imgAlign\" ac:width=\"${imgWidth}\"><ri:url ri:value=\"${src}\"/></ac:image>")
         }
         img.remove()
     }


### PR DESCRIPTION
The current implementation does not respect the custom configuration of an image (i.e. the image width and the image alignment).
Those two attributes are parsed from the original and passed to confluence.