### PR TITLE
Fix failing test for PDF generation with PlantUML

### DIFF
--- a/src/test/docs/test.adoc
+++ b/src/test/docs/test.adoc
@@ -1,6 +1,6 @@
 include::config-de.adoc[]
 
-[plantuml,"${plantUMLDir}testPlant",png]
+[plantuml,"{plantUMLDir}testPlant",png]
 ----
 a --> b
 ----


### PR DESCRIPTION
I'm not sure how it worked for you, but it was failing for me as well as failed in CI without that change.
That $ ends up in the file path, which apparently confuses Linux or Mac, may be working on Windows.